### PR TITLE
Suppress "1 buffer wiped out" confirmation message

### DIFF
--- a/autoload/findr.vim
+++ b/autoload/findr.vim
@@ -236,7 +236,7 @@ function! findr#floating()
     let opts.width -= 4
     set winhl=Normal:FindrBorder
     call nvim_open_win(nvim_create_buf(v:true, v:false), v:true, opts)
-    au BufWipeout <buffer> exe 'bw! '.s:buf
+    au BufWipeout <buffer> exe 'silent bw! '.s:buf
   else
     call nvim_open_win(nvim_create_buf(v:true, v:false), v:true, opts)
   endif


### PR DESCRIPTION
This should prevent the "Press ENTER..." confirmation from happening every time a file is chosen.

<img width="513" alt="Screenshot 2020-01-07 at 11 27 25" src="https://user-images.githubusercontent.com/177685/71888921-5c560d00-3141-11ea-860a-aa6d8aeb580a.png">
