### PR TITLE
Add maps to edit into new split or tab

### DIFF
--- a/doc/Findr.txt
+++ b/doc/Findr.txt
@@ -41,14 +41,20 @@ local to findr buffers
 General maps ~
                                                   *findr_<tab>*
                                                   *findr_<cr>*
+                                                  *findr_<c-x>*
+                                                  *findr_<c-v>*
+                                                  *findr_<c-t>*
 <cr>                      Choose selected item
 <tab>
+<c-x>                       in new split
+<c-v>                       in new vsplit
+<c-t>                       in new tab
 
                                                   *findr_up*
                                                   *findr_<c-p>*
                                                   *findr_<c-k>*
 <up>
-<c-p>                     Select the previous item 
+<c-p>                     Select the previous item
 <c-k>
 
                                                   *findr_down*
@@ -78,7 +84,7 @@ File finder specific maps ~
 <c-l>                     twice to choose file)
 
                                                   *file_findr_<c-h>*
-<c-h>                      Go back to the parent directory of the current
+<c-h>                     Go back to the parent directory of the current
                           directory
 
                                                   *file_findr_<bs>*

--- a/ftplugin/findr.vim
+++ b/ftplugin/findr.vim
@@ -20,7 +20,6 @@ imap <buffer> <s-up> <nop>
 imap <buffer> <s-down> <nop>
 imap <buffer> <M-p> <nop>
 imap <buffer> <M-n> <nop>
-imap <buffer> <c-t> <nop>
 imap <buffer> <c-d> <nop>
 imap <buffer> <c-w> <nop>
 imap <buffer> <c-h> <nop>
@@ -33,6 +32,9 @@ endfor
 imap <buffer><nowait> <cr> <plug>findr_edit
 imap <buffer><nowait> <c-l> <plug>findr_edit
 imap <buffer><nowait> <tab> <plug>findr_edit
+imap <buffer><nowait> <c-t> <plug>findr_tabedit
+imap <buffer><nowait> <c-x> <plug>findr_split
+imap <buffer><nowait> <c-v> <plug>findr_vsplit
 
 imap <buffer><nowait> <c-h> <plug>clear_to_parent
 imap <buffer><nowait> <c-u> <plug>findr_clear

--- a/lua/findr/controller/init.lua
+++ b/lua/findr/controller/init.lua
@@ -154,7 +154,7 @@ function M.backspace()
             M.parent_dir()
         end
     else
-        if api.vim8 then 
+        if api.vim8 then
             api.command('call feedkeys("\\<left>\\<delete>", "n")')
         else
             vim.api.nvim_command('call nvim_feedkeys("\\<BS>", "n", v:true)')
@@ -260,14 +260,14 @@ function M.quit()
     api.command('silent bw '..bufnum)
 end
 
-function M.edit()
+function M.edit(editcmd)
     local fname
     if filetype == 'findr-files' then
         fname = user_io.get_filename(prompt)
     else
         fname = user_io.get_selected(prompt)
     end
-    local command = source.sink(fname)
+    local command = source.sink(fname, editcmd)
     if use_history then
         model.history.update(user_io.get_dir_file_pair(prompt))
         model.history.write()

--- a/lua/findr/controller/maps.lua
+++ b/lua/findr/controller/maps.lua
@@ -18,6 +18,9 @@ function M.set()
     api.set_map('i', '<plug>findr_left', '<cmd>lua findr.controller.left()<cr>', opts)
 
     api.set_map('i', '<plug>findr_edit', '<esc>:lua findr.controller.edit()<cr>', opts)
+    api.set_map('i', '<plug>findr_vsplit', '<esc>:lua findr.controller.edit("vs")<cr>', opts)
+    api.set_map('i', '<plug>findr_split', '<esc>:lua findr.controller.edit("split")<cr>', opts)
+    api.set_map('i', '<plug>findr_tabedit', '<esc>:lua findr.controller.edit("tabedit")<cr>', opts)
     api.set_map('i', '<plug>findr_quit', '<esc>:lua findr.controller.quit()<cr>', opts)
 end
 

--- a/lua/findr/sources/files.lua
+++ b/lua/findr/sources/files.lua
@@ -40,8 +40,9 @@ function M.table()
     return scandir('.')
 end
 
-function M.sink(selected)
-    return 'edit '.. selected
+function M.sink(selected, editcmd)
+    editcmd = editcmd or 'edit'
+    return editcmd..' '.. selected
 end
 
 function M.prompt()


### PR DESCRIPTION
Resolves #11 

This adds three new maps:

* `<c-t>` for opening the selected file into a new tab
* `<c-v>` for opening the selected file into a new vertical split
* `<c-x>` for opening the selected file into a new split

These new mappings leverage `findr.controller.edit` by passing the desired vim command to use when opening the selected file. Currently editing defaults to "edit", and these mappings provide "vs" "split" or "tabedit" to the function.

Following suit with the other mappings, these mappings can be defined by the user by defining `<plug>findr_vsplit`, `<plug>findr_split`, or `<plug>findr_tabedit`.