### PR TITLE
Allow user function to set floating window opts

### DIFF
--- a/doc/Findr.txt
+++ b/doc/Findr.txt
@@ -114,8 +114,26 @@ File finder specific maps ~
 CONFIGURATION                                        *findr_configuration*
 
                                                   *g:findr_floating_window*
-Enable/disable floating window (default 1)
+Enable/disable floating window (default 1). You may also supply a 'dict'
+containing the key "window" with a value that will be evaluated and must
+return the values needed for the config argument in *nvim_open_win*
 (Floating windows are currently only supported on neovim)
+>
+  let g:findr_floating_window = {
+        \ 'window': 'FindrFloatingWindow()'
+        \ }
+
+  function! FindrFloatingWindow()
+    return {
+         \ 'relative': 'editor',
+         \ 'row': 0,
+         \ 'col': 0,
+         \ 'height': &lines - 2,
+         \ 'style': 'minimal',
+         \ 'width': float2nr(&columns / 3)
+         \ }
+  endfunction
+<
 
                                                   *g:findr_enable_border*
 Enable/disable border around floating window (default 1)

--- a/lua/findr/view/init.lua
+++ b/lua/findr/view/init.lua
@@ -13,7 +13,7 @@ local virtual_text = ' '
 local INPUT_LOC = 1
 
 function M.init(filetype)
-    local use_floating = api.get_var('findr_floating_window')==1
+    local use_floating = api.get_var('findr_floating_window') == 1 or type(api.get_var('findr_floating_window')) == type({})
     if use_floating and not api.vim8 then
         window.new_floating(filetype)
     else

--- a/lua/findr/view/window.lua
+++ b/lua/findr/view/window.lua
@@ -14,8 +14,8 @@ end
 function M.new_floating(filetype)
     local use_border = vim.api.nvim_get_var('findr_enable_border') == 1
     local border = vim.api.nvim_get_var('findr_border')
-    local lines = vim.api.nvim_get_option('lines')
     local columns = vim.api.nvim_get_option('columns')
+    local lines = vim.api.nvim_get_option('lines')
     local winopts = api.get_var('findr_floating_window')
     local height, width, options = nil
 

--- a/lua/findr/view/window.lua
+++ b/lua/findr/view/window.lua
@@ -14,22 +14,28 @@ end
 function M.new_floating(filetype)
     local use_border = vim.api.nvim_get_var('findr_enable_border') == 1
     local border = vim.api.nvim_get_var('findr_border')
-    local columns = vim.api.nvim_get_option('columns')
     local lines = vim.api.nvim_get_option('lines')
+    local columns = vim.api.nvim_get_option('columns')
+    local winopts = api.get_var('findr_floating_window')
+    local height, width, options = nil
 
-    local height = math.min(lines - (4+tabline_visible()), 15)
-    local width = math.min(80, columns-4)
-    local horizontal = math.floor((columns-width) / 2)
-    local vertical = 1 + tabline_visible()
+    if type({}) == type(winopts) and winopts['window'] ~= nil then
+      options = vim.api.nvim_eval(winopts['window'])
+      width = options['width']
+      height = options['height']
+    else
+      height = math.min(lines - (4+tabline_visible()), 15)
+      width = math.min(80, columns-4)
+      options = {
+          relative = 'editor',
+          row = 1 + tabline_visible(),
+          col = math.floor((columns-width) / 2),
+          width = width,
+          height = height,
+          style = 'minimal'
+      }
+    end
 
-    local options = {
-        relative = 'editor',
-        row = vertical,
-        col = horizontal,
-        width = width,
-        height = height,
-        style = 'minimal'
-    }
     if use_border then
         local top = border.top[1] .. string.rep(border.top[2], width-2) .. border.top[3]
         local mid = border.middle[1] .. string.rep(border.middle[2], width-2) .. border.middle[3]


### PR DESCRIPTION
Resolves #13 

With these options in the user's own vim settings:

```viml
function! FindrFloatingWindow()
  return {
        \ 'relative': 'editor',
        \ 'row': 0,
        \ 'col': 0,
        \ 'height': &lines - 2,
        \ 'style': 'minimal',
        \ 'width': float2nr(&columns / 3)
        \ }
endfunction

let g:findr_floating_window = {
      \ 'window': 'FindrFloatingWindow()'
      \ }

let g:findr_border = {
      \   'top':    ['─', '─', '┐'],
      \   'middle': [' ', ' ', '│'],
      \   'bottom': ['─', '─', '┘'],
      \ }
```

![image](https://user-images.githubusercontent.com/643967/75727997-7846dc80-5cb4-11ea-8acc-a3591f973898.png)


**TODO**
- [x] Update docs