### PR TITLE
add command to navigate to parent directory

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,6 +27,8 @@ Plug 'conweller/findr.vim'
 
 File finder: `:Findr`
 
+Parent Direcotry of Current File finder: `:FindrParentDir`
+
 Buffer selector: `:FindrBuffers`
 
 Location List selector: `:FindrLocList`

--- a/doc/Findr.txt
+++ b/doc/Findr.txt
@@ -22,6 +22,10 @@ COMMANDS                                          *findr_commands*
 :Findr                          launches a file finder buffer in the current
                                 directory
 
+                                                  *:FindrParentDir*
+:FindrParentDir                 launches a file finder buffer in the parent
+                                directory of current file
+
                                                   *:FindrBuffers*
 :FindrBuffers                   launches a buffer selector
 

--- a/doc/tags
+++ b/doc/tags
@@ -1,4 +1,5 @@
 :Findr	Findr.txt	/*:Findr*
+:FindrParentDir	Findr.txt	/*:FindrParentDir*
 :FindrBuffers	Findr.txt	/*:FindrBuffers*
 :FindrLocList	Findr.txt	/*:FindrLocList*
 :FindrQFList	Findr.txt	/*:FindrQFList*

--- a/plugin/findr.vim
+++ b/plugin/findr.vim
@@ -59,6 +59,7 @@ function! FindrLaunch(source, ...)
 endfunction
 
 command! -complete=dir -nargs=? Findr call FindrLaunch('sources.files', <f-args>)
+command! FindrParentDir call FindrLaunch('sources.files', expand('%:p:h'))
 command! FindrBuffers call FindrLaunch('sources.buffers', './')
 command! FindrLocList call FindrLaunch('sources.loclist', './')
 command! FindrQFList call FindrLaunch('sources.qflist', './')


### PR DESCRIPTION
Emacs `find-file` normally start from the parent directory of current buffer. This is quite useful when the project is deeply nested. I normally want to edit files which lie in the neighborhood. 